### PR TITLE
library.json: specify build includeDir

### DIFF
--- a/library.json
+++ b/library.json
@@ -29,5 +29,8 @@
             "build",
             "**/build"
         ]
+    },
+    "build": {
+        "includeDir": "lwgps/src/include"
     }
 }


### PR DESCRIPTION
Specify includeDir in library.json. 
Fixing issue #31.
Tested by building an application using lwgps via platform IO