### PR TITLE
Add fuzzing by way of ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+COPY . $SRC/lwgps
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/lwgps

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,18 @@
+# ClusterFuzzLite set up
+This folder contains a fuzzing set for [ClusterFuzzLite](https://google.github.io/clusterfuzzlite).
+
+## Reproduce locally
+
+If you'd like to test this the way ClusterFuzzLite runs it (by way of [OSS-Fuzz](https://github.com/google/oss-fuzz)) you can use the steps:
+
+```sh
+git clone https://github.com/google/oss-fuzz
+git clone https://github.com/MaJerle/lwgps lwgps
+cd lwgps
+
+# Build the fuzzers in .clusterfuzzlite
+python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD
+
+# Run the fuzzer for 180 seconds
+python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD process_fuzzer -- -max_total_time=180
+```

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+# Supply build instructions
+# Use the following environment variables to build the code
+# $CXX:               c++ compiler
+# $CC:                c compiler
+# CFLAGS:             compiler flags for C files
+# CXXFLAGS:           compiler flags for CPP files
+# LIB_FUZZING_ENGINE: linker flag for fuzzing harnesses
+mkdir build
+cd build
+cmake ../
+make
+
+# Copy all fuzzer executables to $OUT/
+$CC $CFLAGS $LIB_FUZZING_ENGINE \
+  $SRC/lwgps/.clusterfuzzlite/process_fuzzer.c \
+  -o $OUT/process_fuzzer \
+  $PWD/CMakeFiles/LwLibPROJECT.dir/lwgps/src/lwgps/lwgps.c.o \
+  -I$SRC/lwgps/lwgps/src/include \
+  -I$SRC/lwgps/dev

--- a/.clusterfuzzlite/process_fuzzer.c
+++ b/.clusterfuzzlite/process_fuzzer.c
@@ -1,0 +1,12 @@
+#include <stdint.h>
+#include <lwgps/lwgps.h>
+
+int
+LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    lwgps_t hgps;
+
+    lwgps_init(&hgps);
+    lwgps_process(&hgps, data, size);
+
+    return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ develop ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

I added a fuzzer that targets `lwgps_process`, and currently set the timeout of CFLite to 100 seconds. CFLite will flag if the fuzzer finds  any issues in the code introduced by a PR.

If you'd like to test this the way ClusterFuzzLite runs it (by way of OSS-Fuzz) you can use the steps:

```sh
git clone https://github.com/google/oss-fuzz
git clone https://github.com/DavidKorczynski/lwgps lwgps
cd lwgps
git checkout clusterfuzzlite

# Build the fuzzers in .clusterfuzzlite
python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD

# Run the fuzzer for 180 seconds
python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD process_fuzzer -- -max_total_time=180
```