### PR TITLE
Added dgps_age field

### DIFF
--- a/lwgps/src/include/lwgps/lwgps.h
+++ b/lwgps/src/include/lwgps/lwgps.h
@@ -98,6 +98,7 @@ typedef struct {
     uint8_t hours;           /*!< Hours in UTC */
     uint8_t minutes;         /*!< Minutes in UTC */
     uint8_t seconds;         /*!< Seconds in UTC */
+    lwgps_float_t dgps_age;  /*!< Age of DGPS correction data (in seconds) */
 #endif                       /* LWGPS_CFG_STATEMENT_GPGGA || __DOXYGEN__ */
 
 #if LWGPS_CFG_STATEMENT_GPGSA || __DOXYGEN__
@@ -176,6 +177,7 @@ typedef struct {
                 uint8_t hours;   /*!< Current UTC hours */
                 uint8_t minutes; /*!< Current UTC minutes */
                 uint8_t seconds; /*!< Current UTC seconds */
+                lwgps_float_t dgps_age; /*!< Age of DGPS correction data (in seconds) */
             } gga;               /*!< GPGGA message */
 #endif                           /* LWGPS_CFG_STATEMENT_GPGGA */
 #if LWGPS_CFG_STATEMENT_GPGSA

--- a/lwgps/src/lwgps/lwgps.c
+++ b/lwgps/src/lwgps/lwgps.c
@@ -233,6 +233,9 @@ prv_parse_term(lwgps_t* ghandle) {
             case 11: /* Altitude above ellipsoid */
                 ghandle->p.data.gga.geo_sep = prv_parse_float_number(ghandle, NULL);
                 break;
+            case 13: /* Age of differential GPS correction data */
+                ghandle->p.data.gga.dgps_age = prv_parse_float_number(ghandle, NULL);
+                break;
             default: break;
         }
 #endif /* LWGPS_CFG_STATEMENT_GPGGA */
@@ -394,6 +397,7 @@ prv_copy_from_tmp_memory(lwgps_t* ghandle) {
         ghandle->hours = ghandle->p.data.gga.hours;
         ghandle->minutes = ghandle->p.data.gga.minutes;
         ghandle->seconds = ghandle->p.data.gga.seconds;
+        ghandle->dgps_age = ghandle->p.data.gga.dgps_age;
 #endif /* LWGPS_CFG_STATEMENT_GPGGA */
 #if LWGPS_CFG_STATEMENT_GPGSA
     } else if (ghandle->p.stat == STAT_GSA) {


### PR DESCRIPTION
Added field to store the DGPS age from a GGA message. This field contains the age of the correction data used for the DGPS correction in seconds.