### PR TITLE
Added support for multi-constellation satellite stats. Fixed SNR reporting bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Platform independent GPS NMEA parser for embedded systems.
 * Platform independent, easy to use
 * Built-in support for 4 GPS statements
     * ``GPGGA`` or ``GNGGA``: GPS fix data
-    * ``GPGSA`` or ``GNGSA``: GPS active satellites and dillusion of position
-    * ``GPGSV`` or ``GNGSV``: List of satellites in view zone
+    * ``GPGSA`` or ``GNGSA``: GPS active satellites and dilution of precision
+    * ``G(P/L/A/B)GSV`` or ``GNGSV``: List of satellites in view zone for all constellations
     * ``GPRMC`` or ``GNRMC``: Recommended minimum specific GPS/Transit data
 * Optional ``float`` or ``double`` floating point units
 * Low-level layer is separated from application layer, thus allows you to add custom communication with GPS device

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Platform independent all-constellation GNSS NMEA parser for embedded systems.
 
 * Written in C (C11)
 * Platform independent, easy to use
-* Built-in support for all-constellation GPS statements
-    * ``G*GGA`` or ``GNGGA``: GNSS fix data
-    * ``G*GSA`` or ``GNGSA``: Active satellites and dilution of precision
-    * ``G*GSV`` or ``GNGSV``: List of satellites in view zone
-    * ``G*RMC`` or ``GNRMC``: Recommended minimum specific GNSS/Transit data
+* Built-in support for all-constellation GNSS statements
+    * ``GPGGA``, ``G*GGA`` or ``GNGGA``: GNSS fix data
+    * ``GPGSA``, ``G*GSA`` or ``GNGSA``: Active satellites and dilution of precision
+    * ``GPGSV``, ``G*GSV`` or ``GNGSV``: List of satellites in view zone
+    * ``GPRMC``, ``G*RMC`` or ``GNRMC``: Recommended minimum specific GNSS/Transit data
 * Optional ``float`` or ``double`` floating point units
 * Low-level layer is separated from application layer, thus allows you to add custom communication with GPS device
 * Works with operating systems

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lightweight GPS NMEA parser
 
-Platform independent GPS NMEA parser for embedded systems.
+Platform independent all-constellation GNSS NMEA parser for embedded systems.
 
 <h3>Read first: <a href="http://docs.majerle.eu/projects/lwgps/">Documentation</a></h3>
 
@@ -8,11 +8,11 @@ Platform independent GPS NMEA parser for embedded systems.
 
 * Written in C (C11)
 * Platform independent, easy to use
-* Built-in support for 4 GPS statements
-    * ``GPGGA`` or ``GNGGA``: GPS fix data
-    * ``GPGSA`` or ``GNGSA``: GPS active satellites and dilution of precision
-    * ``G(P/L/A/B)GSV`` or ``GNGSV``: List of satellites in view zone for all constellations
-    * ``GPRMC`` or ``GNRMC``: Recommended minimum specific GPS/Transit data
+* Built-in support for all-constellation GPS statements
+    * ``G*GGA`` or ``GNGGA``: GNSS fix data
+    * ``G*GSA`` or ``GNGSA``: Active satellites and dilution of precision
+    * ``G*GSV`` or ``GNGSV``: List of satellites in view zone
+    * ``G*RMC`` or ``GNRMC``: Recommended minimum specific GNSS/Transit data
 * Optional ``float`` or ``double`` floating point units
 * Low-level layer is separated from application layer, thus allows you to add custom communication with GPS device
 * Works with operating systems

--- a/lwgps/src/include/lwgps/lwgps.h
+++ b/lwgps/src/include/lwgps/lwgps.h
@@ -37,7 +37,7 @@
 #include <limits.h>
 #include <stddef.h>
 #include <stdint.h>
-#include "lwgps_opt.h"
+#include "lwgps/lwgps_opt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/lwgps/src/include/lwgps/lwgps.h
+++ b/lwgps/src/include/lwgps/lwgps.h
@@ -63,7 +63,7 @@ typedef float lwgps_float_t;
  * \brief           Satellite descriptor
  */
 typedef struct {
-    uint16_t num;      /*!< Satellite number */
+    uint8_t num;       /*!< Satellite number */
     uint8_t elevation; /*!< Elevation in degrees */
     uint16_t azimuth;  /*!< Azimuth in degrees */
     uint8_t snr;       /*!< Signal-to-noise ratio */

--- a/lwgps/src/include/lwgps/lwgps.h
+++ b/lwgps/src/include/lwgps/lwgps.h
@@ -37,7 +37,7 @@
 #include <limits.h>
 #include <stddef.h>
 #include <stdint.h>
-#include "lwgps/lwgps_opt.h"
+#include "lwgps_opt.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -63,8 +63,8 @@ typedef float lwgps_float_t;
  * \brief           Satellite descriptor
  */
 typedef struct {
-    uint8_t num;       /*!< Satellite number */
-    uint8_t elevation; /*!< Elevation value */
+    uint16_t num;      /*!< Satellite number */
+    uint8_t elevation; /*!< Elevation in degrees */
     uint16_t azimuth;  /*!< Azimuth in degrees */
     uint8_t snr;       /*!< Signal-to-noise ratio */
 } lwgps_sat_t;
@@ -113,9 +113,11 @@ typedef struct {
 
 #if LWGPS_CFG_STATEMENT_GPGSV || __DOXYGEN__
     /* Information related to GPGSV statement */
-    uint8_t sats_in_view; /*!< Number of satellites in view */
+    uint8_t sats_in_view;        /*!< Number of satellites in view (accumulated across all constellations/signals) */
+    uint8_t gsv_series_offset;   /*!< Running satellite descriptor index offset for multi-series accumulation */
+    uint8_t gsv_cycle_active;    /*!< Flag: GSV cycle in progress for this NMEA epoch */
 #if LWGPS_CFG_STATEMENT_GPGSV_SAT_DET || __DOXYGEN__
-    lwgps_sat_t sats_in_view_desc[12];
+    lwgps_sat_t sats_in_view_desc[LWGPS_CFG_SATS_IN_VIEW_SIZE];
 #endif /* LWGPS_CFG_STATEMENT_GPGSV_SAT_DET || __DOXYGEN__ */
 #endif /* LWGPS_CFG_STATEMENT_GPGSV || __DOXYGEN__ */
 
@@ -195,8 +197,11 @@ typedef struct {
 #endif                                      /* LWGPS_CFG_STATEMENT_GPGSA */
 #if LWGPS_CFG_STATEMENT_GPGSV
             struct {
-                uint8_t sats_in_view; /*!< Number of stallites in view */
-                uint8_t stat_num;     /*!< Satellite line number during parsing GPGSV data */
+                uint8_t sats_in_view; /*!< Number of satellites in view for this series */
+                uint8_t stat_num;     /*!< Current message number within this GSV series */
+                uint8_t num_msgs;     /*!< Total number of messages in this GSV series */
+                uint8_t gnss;         /*!< Constellation from talker ID (\ref lwgps_gnss_t) */
+                uint8_t signal_id;    /*!< Signal/band ID (NMEA 4.10+) */
             } gsv;                    /*!< GPGSV message */
 #endif                                /* LWGPS_CFG_STATEMENT_GPGSV */
 #if LWGPS_CFG_STATEMENT_GPRMC

--- a/lwgps/src/include/lwgps/lwgps_opt.h
+++ b/lwgps/src/include/lwgps/lwgps_opt.h
@@ -130,6 +130,17 @@ extern "C" {
 #endif
 
 /**
+ * \brief           Maximum number of satellite descriptors stored in \ref lwgps_t::sats_in_view_desc.
+ *
+ *                  48 covers GPS(32) + GLONASS(24) + Galileo(24) + BeiDou(35) worst-case
+ *                  visible subsets. Increase if more are needed; decrease to save RAM
+ *                  (~8 bytes per descriptor).
+ */
+#ifndef LWGPS_CFG_SATS_IN_VIEW_SIZE
+#define LWGPS_CFG_SATS_IN_VIEW_SIZE 48
+#endif
+
+/**
  * \brief           Enables `1` or disables `0` parsing and generation
  *                  of PUBX (uBlox) messages
  *

--- a/lwgps/src/lwgps/lwgps.c
+++ b/lwgps/src/lwgps/lwgps.c
@@ -173,19 +173,23 @@ prv_parse_term(lwgps_t* ghandle) {
     if (ghandle->p.term_num == 0) { /* Check string type */
         if (0) {
 #if LWGPS_CFG_STATEMENT_GPGGA
-        } else if (!strncmp(ghandle->p.term_str, "$GPGGA", 6) || !strncmp(ghandle->p.term_str, "$GNGGA", 6)) {
+        } else if (ghandle->p.term_str[0] == '$' && ghandle->p.term_str[1] == 'G'
+                && !strncmp(ghandle->p.term_str + 3, "GGA", 3)) {
             ghandle->p.stat = STAT_GGA;
 #endif /* LWGPS_CFG_STATEMENT_GPGGA */
 #if LWGPS_CFG_STATEMENT_GPGSA
-        } else if (!strncmp(ghandle->p.term_str, "$GPGSA", 6) || !strncmp(ghandle->p.term_str, "$GNGSA", 6)) {
+        } else if (ghandle->p.term_str[0] == '$' && ghandle->p.term_str[1] == 'G'
+                && !strncmp(ghandle->p.term_str + 3, "GSA", 3)) {
             ghandle->p.stat = STAT_GSA;
 #endif /* LWGPS_CFG_STATEMENT_GPGSA */
 #if LWGPS_CFG_STATEMENT_GPGSV
-        } else if (!strncmp(ghandle->p.term_str, "$GPGSV", 6) || !strncmp(ghandle->p.term_str, "$GNGSV", 6)) {
+        } else if (ghandle->p.term_str[0] == '$' && ghandle->p.term_str[1] == 'G'
+                && !strncmp(ghandle->p.term_str + 3, "GSV", 3)) {
             ghandle->p.stat = STAT_GSV;
 #endif /* LWGPS_CFG_STATEMENT_GPGSV */
 #if LWGPS_CFG_STATEMENT_GPRMC
-        } else if (!strncmp(ghandle->p.term_str, "$GPRMC", 6) || !strncmp(ghandle->p.term_str, "$GNRMC", 6)) {
+        } else if (ghandle->p.term_str[0] == '$' && ghandle->p.term_str[1] == 'G'
+                && !strncmp(ghandle->p.term_str + 3, "RMC", 3)) {
             ghandle->p.stat = STAT_RMC;
 #endif /* LWGPS_CFG_STATEMENT_GPRMC */
 #if LWGPS_CFG_STATEMENT_PUBX
@@ -262,8 +266,20 @@ prv_parse_term(lwgps_t* ghandle) {
 #if LWGPS_CFG_STATEMENT_GPGSV
     } else if (ghandle->p.stat == STAT_GSV) { /* Process GPGSV statement */
         switch (ghandle->p.term_num) {
-            case 2: /* Current GPGSV statement number */
+            case 1: /* Total number of messages in this GSV series */
+                ghandle->p.data.gsv.num_msgs = (uint8_t)prv_parse_number(ghandle, NULL);
+                break;
+            case 2: /* Current message number within this GSV series */
                 ghandle->p.data.gsv.stat_num = (uint8_t)prv_parse_number(ghandle, NULL);
+                if (ghandle->p.data.gsv.stat_num == 1 && !ghandle->gsv_cycle_active) {
+                    /* First GSV series of this NMEA cycle: clear stale satellite data */
+#if LWGPS_CFG_STATEMENT_GPGSV_SAT_DET
+                    LWGPS_MEMSET(ghandle->sats_in_view_desc, 0, sizeof(ghandle->sats_in_view_desc));
+#endif /* LWGPS_CFG_STATEMENT_GPGSV_SAT_DET */
+                    ghandle->gsv_series_offset = 0;
+                    ghandle->sats_in_view = 0;
+                    ghandle->gsv_cycle_active = 1;
+                }
                 break;
             case 3: /* Process satellites in view */
                 ghandle->p.data.gsv.sats_in_view = (uint8_t)prv_parse_number(ghandle, NULL);
@@ -271,17 +287,23 @@ prv_parse_term(lwgps_t* ghandle) {
             default:
 #if LWGPS_CFG_STATEMENT_GPGSV_SAT_DET
                 if (ghandle->p.term_num >= 4 && ghandle->p.term_num <= 19) { /* Check current term number */
-                    uint8_t index, term_num = ghandle->p.term_num - 4; /* Normalize term number from 4-19 to 0-15 */
-                    uint16_t value;
+                    uint8_t term_num = ghandle->p.term_num - 4; /* Normalize term number from 4-19 to 0-15 */
+                    uint8_t sat_offset = term_num >> 2;          /* Satellite offset within this message (0-3) */
 
-                    index = ((ghandle->p.data.gsv.stat_num - 1) << 0x02) + (term_num >> 2); /* Get array index */
+                    /* Reject terms beyond the declared satellite count (e.g. NMEA 4.10+ signal ID field) */
+                    uint8_t sat_in_series = ((ghandle->p.data.gsv.stat_num - 1) << 0x02) + sat_offset;
+                    if (sat_in_series >= ghandle->p.data.gsv.sats_in_view) {
+                        break;
+                    }
+
+                    uint8_t index = ghandle->gsv_series_offset + sat_in_series; /* Absolute index across all series */
                     if (index < sizeof(ghandle->sats_in_view_desc) / sizeof(ghandle->sats_in_view_desc[0])) {
-                        value = (uint16_t)prv_parse_number(ghandle, NULL); /* Parse number as integer */
+                        uint16_t value = (uint16_t)prv_parse_number(ghandle, NULL); /* Parse number as integer */
                         switch (term_num & 0x03) {
                             case 0: ghandle->sats_in_view_desc[index].num = value; break;
-                            case 1: ghandle->sats_in_view_desc[index].elevation = value; break;
+                            case 1: ghandle->sats_in_view_desc[index].elevation = (uint8_t)value; break;
                             case 2: ghandle->sats_in_view_desc[index].azimuth = value; break;
-                            case 3: ghandle->sats_in_view_desc[index].snr = value; break;
+                            case 3: ghandle->sats_in_view_desc[index].snr = (uint8_t)value; break;
                             default: break;
                         }
                     }
@@ -400,6 +422,12 @@ prv_check_crc(lwgps_t* ghandle) {
  */
 static uint8_t
 prv_copy_from_tmp_memory(lwgps_t* ghandle) {
+#if LWGPS_CFG_STATEMENT_GPGSV
+    /* End GSV cycle when a non-GSV sentence completes */
+    if (ghandle->p.stat != STAT_GSV && ghandle->gsv_cycle_active) {
+        ghandle->gsv_cycle_active = 0;
+    }
+#endif /* LWGPS_CFG_STATEMENT_GPGSV */
     if (0) {
 #if LWGPS_CFG_STATEMENT_GPGGA
     } else if (ghandle->p.stat == STAT_GGA) {
@@ -425,7 +453,11 @@ prv_copy_from_tmp_memory(lwgps_t* ghandle) {
 #endif /* LWGPS_CFG_STATEMENT_GPGSA */
 #if LWGPS_CFG_STATEMENT_GPGSV
     } else if (ghandle->p.stat == STAT_GSV) {
-        ghandle->sats_in_view = ghandle->p.data.gsv.sats_in_view;
+        /* Accumulate sats_in_view: add this series' count once (when its last message completes) */
+        if (ghandle->p.data.gsv.stat_num == ghandle->p.data.gsv.num_msgs) {
+            ghandle->sats_in_view += ghandle->p.data.gsv.sats_in_view;
+            ghandle->gsv_series_offset = ghandle->sats_in_view;
+        }
 #endif /* LWGPS_CFG_STATEMENT_GPGSV */
 #if LWGPS_CFG_STATEMENT_GPRMC
     } else if (ghandle->p.stat == STAT_RMC) {

--- a/lwgps/src/lwgps/lwgps.c
+++ b/lwgps/src/lwgps/lwgps.c
@@ -300,7 +300,7 @@ prv_parse_term(lwgps_t* ghandle) {
                     if (index < sizeof(ghandle->sats_in_view_desc) / sizeof(ghandle->sats_in_view_desc[0])) {
                         uint16_t value = (uint16_t)prv_parse_number(ghandle, NULL); /* Parse number as integer */
                         switch (term_num & 0x03) {
-                            case 0: ghandle->sats_in_view_desc[index].num = value; break;
+                            case 0: ghandle->sats_in_view_desc[index].num = (uint8_t)value; break;
                             case 1: ghandle->sats_in_view_desc[index].elevation = (uint8_t)value; break;
                             case 2: ghandle->sats_in_view_desc[index].azimuth = value; break;
                             case 3: ghandle->sats_in_view_desc[index].snr = (uint8_t)value; break;


### PR DESCRIPTION
Hello,

i'm currently using your library to parse NMEA from a ublox M10 receiver, which is running at default settings.

I noticed that the number of satellites-in-view vs used-for-positioning satellites is inplausible, when going from an GNSS-denied indoor environment to outdoors: The number of used satellites is intermittently shown to be higher than the number of satellites in view!

I tracked this down to the library not parsing all constellation variants of the G*GSV messages. This clashes with the satellites-in-view value reported by GNGGA, which is for all constellations.

Another issue was the SNR always being reported as 0, even when outdoors with good position and HDoP.
This had to do with GPS multi-band reporting. The multi-band data overwrites the values reported for standard L1 band. The sats_in_view_desc is now cleared only once per NMEA cycle and multi-band/multi-constellation data now handled correctly.

This proposal supports GPS, Galileo, BeiDou and GLONASS and has configurable satellite stats size, with the config option "LWGPS_CFG_SATS_IN_VIEW_SIZE", so the user can track as many satellites as needed.

Regards, Florian.