### PR TITLE
Add ESP-IDF support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,20 @@
 cmake_minimum_required(VERSION 3.22)
 
 if(DEFINED IDF_PATH)
+    set(LWGPS_CUSTOM_INC_DIR ${CMAKE_CURRENT_BINARY_DIR}/lib_inc)
+
+    if(NOT LWGPS_OPTS_FILE)
+        message(STATUS "Using default lwgps_opts.h file")
+        set(LWGPS_OPTS_FILE ${CMAKE_CURRENT_LIST_DIR}/lwgps/src/include/lwgps/lwgps_opts_template.h)
+    else()
+        message(STATUS "Using custom lwgps_opts.h file from ${LWGPS_OPTS_FILE}")
+    endif()
+
+    configure_file(${LWGPS_OPTS_FILE} ${LWGPS_CUSTOM_INC_DIR}/lwgps_opts.h COPYONLY)
+
     idf_component_register(
         SRCS "lwgps/src/lwgps/lwgps.c"
-        INCLUDE_DIRS "lwgps/src/include"
+        INCLUDE_DIRS "lwgps/src/include" ${LWGPS_CUSTOM_INC_DIR}
     )
     return()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.22)
 
-if(DEFINED IDF_PATH)
+if(DEFINED ESP_PLATFORM)
     set(LWGPS_CUSTOM_INC_DIR ${CMAKE_CURRENT_BINARY_DIR}/lib_inc)
 
     if(NOT LWGPS_OPTS_FILE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.22)
 
-# Setup project
+if(DEFINED IDF_PATH)
+    idf_component_register(
+        SRCS "lwgps/src/lwgps/lwgps.c"
+        INCLUDE_DIRS "lwgps/src/include"
+    )
+    return()
+endif()
+
+# Standalone / subdirectory build
 project(LwLibPROJECT)
 
 if(NOT PROJECT_IS_TOP_LEVEL)

--- a/README.md
+++ b/README.md
@@ -38,3 +38,19 @@ To build the code and run basic tests on your host::
 
         cd examples
         make test
+
+## ESP-IDF integration
+
+To use lwgps as an ESP-IDF component, add the repository to your project as a managed component or a local component directory, then point the build at your options header before lwgps is configured.
+
+If you want to keep the configuration file inside your own component, add a `project_include.cmake` file to that component with:
+
+```cmake
+set(LWGPS_OPTS_FILE "${COMPONENT_DIR}/lwgps_opts.h")
+```
+
+Then make sure that component depends on `lwgps` via `REQUIRES` or `PRIV_REQUIRES`, and place your `lwgps_opts.h` file next to the component `CMakeLists.txt`.
+
+If you prefer to set it at the project level instead, define `LWGPS_OPTS_FILE` in the top-level `CMakeLists.txt` before `include($ENV{IDF_PATH}/tools/cmake/project.cmake)`.
+
+The configuration file should be a copy of `lwgps/src/include/lwgps/lwgps_opts_template.h` renamed to `lwgps_opts.h`.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Platform independent all-constellation GNSS NMEA parser for embedded systems.
 * Low-level layer is separated from application layer, thus allows you to add custom communication with GPS device
 * Works with operating systems
 * Works with different communication interfaces
+* Can be used as an ESP-IDF component
 * User friendly MIT license
 
 ## Contribute
@@ -38,19 +39,3 @@ To build the code and run basic tests on your host::
 
         cd examples
         make test
-
-## ESP-IDF integration
-
-To use lwgps as an ESP-IDF component, add the repository to your project as a managed component or a local component directory, then point the build at your options header before lwgps is configured.
-
-If you want to keep the configuration file inside your own component, add a `project_include.cmake` file to that component with:
-
-```cmake
-set(LWGPS_OPTS_FILE "${COMPONENT_DIR}/lwgps_opts.h")
-```
-
-Then make sure that component depends on `lwgps` via `REQUIRES` or `PRIV_REQUIRES`, and place your `lwgps_opts.h` file next to the component `CMakeLists.txt`.
-
-If you prefer to set it at the project level instead, define `LWGPS_OPTS_FILE` in the top-level `CMakeLists.txt` before `include($ENV{IDF_PATH}/tools/cmake/project.cmake)`.
-
-The configuration file should be a copy of `lwgps/src/include/lwgps/lwgps_opts_template.h` renamed to `lwgps_opts.h`.

--- a/docs/get-started/index.rst
+++ b/docs/get-started/index.rst
@@ -92,6 +92,24 @@ and it should be copied (or simply renamed in-place) and named ``lwgps_opts.h``
     If you are using *CMake* build system, define the variable ``LWGPS_OPTS_FILE`` before adding library's directory to the *CMake* project.
     Variable must contain the path to the user options file. If not provided and to avoid build error, one will be generated in the build directory.
 
+ESP-IDF integration
+*******************
+
+To use LwGPS as an ESP-IDF component, add the repository to your project as a managed component or a local component directory.
+Then point the build at your options header before LwGPS is configured.
+
+If you want to keep the configuration file inside your own component, add a ``project_include.cmake`` file to that component with:
+
+.. code-block:: cmake
+
+    set(LWGPS_OPTS_FILE "${COMPONENT_DIR}/lwgps_opts.h")
+
+Then make sure that component depends on ``lwgps`` via ``REQUIRES`` or ``PRIV_REQUIRES``, and place your ``lwgps_opts.h`` file next to the component ``CMakeLists.txt``.
+
+If you prefer to set it at the project level instead, define ``LWGPS_OPTS_FILE`` in the top-level ``CMakeLists.txt`` before ``include($ENV{IDF_PATH}/tools/cmake/project.cmake)``.
+
+The configuration file should be a copy of ``lwgps/src/include/lwgps/lwgps_opts_template.h`` renamed to ``lwgps_opts.h``.
+
 Configuration options list is available available in the :ref:`api_lwgps_opt` section.
 If any option is about to be modified, it should be done in configuration file
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ Features
 * Low-level layer is separated from application layer, thus allows you to add custom communication with GPS device
 * Works with operating systems
 * Works with different communication interfaces
+* Can be used as an ESP-IDF component
 * User friendly MIT license
 
 Requirements
@@ -92,4 +93,3 @@ Table of contents
     LwSHELL - Shell <https://github.com/MaJerle/lwshell>
     LwUTIL - Utility functions <https://github.com/MaJerle/lwutil>
     LwWDG - RTOS task watchdog <https://github.com/MaJerle/lwwdg>
-

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+  idf: ">=5.0"


### PR DESCRIPTION
This pull request adds support for integrating the `lwgps` library as a component in ESP-IDF projects. The changes introduce conditional CMake logic for ESP-IDF and updates README.md with integration instructions.

ESP-IDF integration:

* Added conditional logic in `CMakeLists.txt` to detect ESP-IDF builds, configure the options header (`lwgps_opts.h`), and register `lwgps` as an ESP-IDF component. This allows users to customize configuration and seamlessly include the library in their ESP-IDF projects.
* Added `idf_component.yml` with a dependency on ESP-IDF version 5.0 or higher, ensuring compatibility with modern ESP-IDF toolchains.

Documentation updates:

* Updated `README.md` with detailed instructions for integrating `lwgps` as an ESP-IDF component, including configuration options and example CMake usage.