### PR TITLE
Guard PUBX,04 (STAT_UBX_TIME) time/date/leap_sec fields against truncated terms

### DIFF
--- a/lwgps/src/lwgps/lwgps.c
+++ b/lwgps/src/lwgps/lwgps.c
@@ -359,14 +359,26 @@ prv_parse_term(lwgps_t* ghandle) {
     } else if (ghandle->p.stat == STAT_UBX_TIME) { /* Process PUBX (uBlox) TIME statement */
         switch (ghandle->p.term_num) {
             case 2: /* Process UTC time; ignore fractions of seconds */
-                ghandle->p.data.time.hours = 10U * CTN(ghandle->p.term_str[0]) + CTN(ghandle->p.term_str[1]);
-                ghandle->p.data.time.minutes = 10U * CTN(ghandle->p.term_str[2]) + CTN(ghandle->p.term_str[3]);
-                ghandle->p.data.time.seconds = 10U * CTN(ghandle->p.term_str[4]) + CTN(ghandle->p.term_str[5]);
+                if (ghandle->p.term_pos >= 6) {
+                    ghandle->p.data.time.hours = 10U * CTN(ghandle->p.term_str[0]) + CTN(ghandle->p.term_str[1]);
+                    ghandle->p.data.time.minutes = 10U * CTN(ghandle->p.term_str[2]) + CTN(ghandle->p.term_str[3]);
+                    ghandle->p.data.time.seconds = 10U * CTN(ghandle->p.term_str[4]) + CTN(ghandle->p.term_str[5]);
+                } else {
+                    ghandle->p.data.time.hours = 0;
+                    ghandle->p.data.time.minutes = 0;
+                    ghandle->p.data.time.seconds = 0;
+                }
                 break;
             case 3: /* Process UTC date */
-                ghandle->p.data.time.date = 10U * CTN(ghandle->p.term_str[0]) + CTN(ghandle->p.term_str[1]);
-                ghandle->p.data.time.month = 10U * CTN(ghandle->p.term_str[2]) + CTN(ghandle->p.term_str[3]);
-                ghandle->p.data.time.year = 10U * CTN(ghandle->p.term_str[4]) + CTN(ghandle->p.term_str[5]);
+                if (ghandle->p.term_pos >= 6) {
+                    ghandle->p.data.time.date = 10U * CTN(ghandle->p.term_str[0]) + CTN(ghandle->p.term_str[1]);
+                    ghandle->p.data.time.month = 10U * CTN(ghandle->p.term_str[2]) + CTN(ghandle->p.term_str[3]);
+                    ghandle->p.data.time.year = 10U * CTN(ghandle->p.term_str[4]) + CTN(ghandle->p.term_str[5]);
+                } else {
+                    ghandle->p.data.time.date = 0;
+                    ghandle->p.data.time.month = 0;
+                    ghandle->p.data.time.year = 0;
+                }
                 break;
             case 4: /* Process UTC TimeOfWeek */
                 ghandle->p.data.time.utc_tow = prv_parse_float_number(ghandle, NULL);
@@ -377,7 +389,9 @@ prv_parse_term(lwgps_t* ghandle) {
 				 * Accomodate a 2- or 3-digit leap second count
                  * a trailing 'D' means this is the firmware's default value.
                  */
-                if (ghandle->p.term_str[2] == 'D' || ghandle->p.term_str[2] == '\0') {
+                if (ghandle->p.term_pos < 2) {
+                    ghandle->p.data.time.leap_sec = 0;
+                } else if (ghandle->p.term_str[2] == 'D' || ghandle->p.term_str[2] == '\0') {
                     ghandle->p.data.time.leap_sec = 10U * CTN(ghandle->p.term_str[0]) + CTN(ghandle->p.term_str[1]);
                 } else {
                     ghandle->p.data.time.leap_sec = 100U * CTN(ghandle->p.term_str[0])

--- a/tests/test_parse_ext_time/test_parse_ext_time.c
+++ b/tests/test_parse_ext_time/test_parse_ext_time.c
@@ -30,6 +30,9 @@ const char gps_rx_data_A[] = ""
 const char gps_rx_data_B[] = ""
                              "$PUBX,04,200714.00,230320,158834.00,2098,18,536057,257.043,16*12\r\n"
                              "";
+const char gps_rx_data_C[] = ""
+                             "$PUBX,04,1,2,0,0,3,0,0,0*37\r\n"
+                             "";
 
 /**
  * \brief           Run the test of raw input data
@@ -69,6 +72,17 @@ test_run(void) {
     RUN_TEST(INT_IS_EQUAL(hgps.clk_bias, 536057));
     RUN_TEST(FLT_IS_EQUAL(hgps.clk_drift, 257.043));
     RUN_TEST(INT_IS_EQUAL(hgps.tp_gran, 16));
+
+    /* Process and test truncated time, date, and leap-second fields */
+    lwgps_process(&hgps, gps_rx_data_C, strlen(gps_rx_data_C));
+
+    RUN_TEST(INT_IS_EQUAL(hgps.hours, 0));
+    RUN_TEST(INT_IS_EQUAL(hgps.minutes, 0));
+    RUN_TEST(INT_IS_EQUAL(hgps.seconds, 0));
+    RUN_TEST(INT_IS_EQUAL(hgps.date, 0));
+    RUN_TEST(INT_IS_EQUAL(hgps.month, 0));
+    RUN_TEST(INT_IS_EQUAL(hgps.year, 0));
+    RUN_TEST(INT_IS_EQUAL(hgps.leap_sec, 0));
 
     return 0;
 }


### PR DESCRIPTION
## Problem

`STAT_GGA` and `STAT_RMC` already guard their UTC time/date term parsing with a `term_pos >= 6` check before decoding the `hhmmss`/`ddmmyy` digit pairs, falling back to zero when the field is shorter than expected (added for the GGA/RMC case discussed in #38 / #17).

The `PUBX,04` (`STAT_UBX_TIME`) handler never got the equivalent guard for its time (case 2), date (case 3) and leap-second (case 6) terms. If the field is truncated or empty, `CTN()` reads past the end of the actual digits (stale bytes left over in the shared `term_str` buffer from a previous term in the same sentence, or the implicit `'\0'` terminator), producing out-of-range values instead of being rejected — e.g. `seconds > 59`, `month > 12`.

Repro (truncated time field `"07"` instead of `hhmmss`, empty date field):

```
$PUBX,04,07,,113851.00,1196,15D,1930035,-2660.664,43*51
```

Before this fix, this produced illegal values such as `hours=7 minutes=50 seconds=96 date=39 month=50 year=96`. The equivalent truncated `$GPGGA` sentence correctly falls back to `time_valid=0, hours=minutes=seconds=0` thanks to its existing guard — `STAT_UBX_TIME` had no such fallback and its garbage values are copied unconditionally into the public `ghandle` fields in `prv_copy_from_tmp_memory()`, silently clobbering any previously-valid time.

## Fix

Apply the same "zero on insufficient length" fallback already used by GGA/RMC to the three affected `STAT_UBX_TIME` cases, and add a `term_pos < 2` guard before the leap-second case inspects `term_str[2]`.

## Testing

- Built with `gcc -std=c99 -Wall -Wextra`, zero warnings.
- Ran the project's own test suite (`tests/test_parse_ext_time`, `tests/test_parse_standard`, `tests/test_parse_beidou`, `tests/test_parse_sat_det`, via the same CMake+Ninja flow `tests/test.py` uses) against the patched source — all four pass with 0 failures, including `test_parse_ext_time` which exercises well-formed `$PUBX,04` sentences.
- Manually reproduced the truncated-field repro above against the unpatched source (illegal `seconds=96`, `month=50`), then confirmed the patched source correctly zeroes the fields instead.